### PR TITLE
Cambiar estrategia de relación en Sesiones

### DIFF
--- a/backend/src/main/java/com/abel/eventos/infrastructure/adapter/out/persistence/adapter/SesionRepositoryAdapter.java
+++ b/backend/src/main/java/com/abel/eventos/infrastructure/adapter/out/persistence/adapter/SesionRepositoryAdapter.java
@@ -3,7 +3,6 @@ package com.abel.eventos.infrastructure.adapter.out.persistence.adapter;
 import com.abel.eventos.application.port.out.SesionRepositoryPort;
 import com.abel.eventos.domain.model.Asiento;
 import com.abel.eventos.domain.model.Sesion;
-import com.abel.eventos.infrastructure.adapter.out.persistence.entity.EventoEntity;
 import com.abel.eventos.infrastructure.adapter.out.persistence.entity.SesionAsientoEntity;
 import com.abel.eventos.infrastructure.adapter.out.persistence.entity.SesionEntity;
 import com.abel.eventos.infrastructure.adapter.out.persistence.entity.UsuarioEntity;
@@ -74,12 +73,8 @@ public class SesionRepositoryAdapter implements SesionRepositoryPort {
             entity.setUsuario(usuarioRef);
         }
 
-        // Referencia al evento (puede ser null al inicio)
-        if (sesion.getEventoId() != null) {
-            EventoEntity eventoRef = new EventoEntity();
-            eventoRef.setId(sesion.getEventoId());
-            entity.setEvento(eventoRef);
-        }
+        // Guardar evento ID directamente (sin relación JPA)
+        entity.setEventoId(sesion.getEventoId());
 
         // Convertir asientos seleccionados
         if (sesion.getAsientosSeleccionados() != null) {
@@ -109,9 +104,8 @@ public class SesionRepositoryAdapter implements SesionRepositoryPort {
             sesion.setUsuarioId(entity.getUsuario().getId());
         }
 
-        if (entity.getEvento() != null) {
-            sesion.setEventoId(entity.getEvento().getId());
-        }
+        // Obtener evento ID directamente
+        sesion.setEventoId(entity.getEventoId());
 
         // Convertir asientos seleccionados
         if (entity.getAsientosSeleccionados() != null) {

--- a/backend/src/main/java/com/abel/eventos/infrastructure/adapter/out/persistence/entity/SesionEntity.java
+++ b/backend/src/main/java/com/abel/eventos/infrastructure/adapter/out/persistence/entity/SesionEntity.java
@@ -36,9 +36,8 @@ public class SesionEntity {
     @JoinColumn(name = "usuario_id", nullable = false)
     private UsuarioEntity usuario;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "evento_id")
-    private EventoEntity evento;
+    @Column(name = "evento_id")
+    private Long eventoId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)


### PR DESCRIPTION
## Descripcion
Se modifica `SesionEntity` para almacenar el `eventoId` como un dato simple (Long) en lugar de una relación fuerte de base de datos. Esto permite guardar sesiones de compra incluso si el evento aún no existe físicamente en la tabla eventos local.

## Issue Relacionado
closes #40 